### PR TITLE
Add animations in FBX. (add material in fbx but it's not useable for now)

### DIFF
--- a/LibXenoverse/LibXenoverse/EAN.cpp
+++ b/LibXenoverse/LibXenoverse/EAN.cpp
@@ -66,4 +66,518 @@ namespace LibXenoverse {
 	void EAN::write(File *file) {
 
 	}
+
+
+#ifdef LIBXENOVERSE_FBX_SUPPORT
+	FbxAnimCurveNode *EAN::createFBXAnimationCurveNode(FbxNode *fbx_node, EANAnimation *animation, EANAnimationNode* anim_node, FbxAnimStack *lAnimStack, FbxAnimLayer* lAnimLayer) {
+
+
+		float fps = 60.0f;			//TODO configure.
+
+		FbxAnimCurveNode *fbx_animCurveNode = fbx_node->GeometricTranslation.GetCurveNode(lAnimLayer, true);
+		
+
+		FbxAnimCurve *fbx_animCurve_translation_x = fbx_node->LclTranslation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_X, true);
+		FbxAnimCurve *fbx_animCurve_translation_y = fbx_node->LclTranslation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+		FbxAnimCurve *fbx_animCurve_translation_z = fbx_node->LclTranslation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+		FbxAnimCurve *fbx_animCurve_rotation_x = fbx_node->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_X, true);
+		FbxAnimCurve *fbx_animCurve_rotation_y = fbx_node->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+		FbxAnimCurve *fbx_animCurve_rotation_z = fbx_node->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+		FbxAnimCurve *fbx_animCurve_scale_x = fbx_node->LclScaling.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_X, true);
+		FbxAnimCurve *fbx_animCurve_scale_y = fbx_node->LclScaling.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+		FbxAnimCurve *fbx_animCurve_scale_z = fbx_node->LclScaling.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+		
+		
+		if (fbx_animCurve_translation_x)
+			fbx_animCurve_translation_x->KeyModifyBegin();
+		if (fbx_animCurve_translation_y)
+			fbx_animCurve_translation_y->KeyModifyBegin();
+		if (fbx_animCurve_translation_z)
+			fbx_animCurve_translation_z->KeyModifyBegin();
+		if (fbx_animCurve_rotation_x)
+			fbx_animCurve_rotation_x->KeyModifyBegin();
+		if (fbx_animCurve_rotation_y)
+			fbx_animCurve_rotation_y->KeyModifyBegin();
+		if (fbx_animCurve_rotation_z)
+			fbx_animCurve_rotation_z->KeyModifyBegin();
+		if (fbx_animCurve_scale_x)
+			fbx_animCurve_scale_x->KeyModifyBegin();
+		if (fbx_animCurve_scale_y)
+			fbx_animCurve_scale_y->KeyModifyBegin();
+		if (fbx_animCurve_scale_z)
+			fbx_animCurve_scale_z->KeyModifyBegin();
+
+		if ((string(animation->getName()) == "APL_BAS_STAND") || (string(animation->getName()) == "APL_ATC_012") || (string(animation->getName()) == "APL_NAG_D") )
+			int aa = 42;
+
+
+		FbxTime lTime;
+		int lKeyIndex = 0;
+		size_t frame_count = animation->getFrameCount();
+		for (size_t i = 0; i < frame_count; i++) {
+
+			float frame = (float)i / fps;
+			
+			float px = 0, py = 0, pz = 0, pw = 0;
+			float rx = 0, ry = 0, rz = 0, rw = 1.0f;
+			float sx = 1.0f, sy = 1.0f, sz = 1.0f, sw = 0;
+			anim_node->getInterpolatedFrame(i, LIBXENOVERSE_EAN_KEYFRAMED_ANIMATION_FLAG_POSITION, px, py, pz, pw);
+			anim_node->getInterpolatedFrame(i, LIBXENOVERSE_EAN_KEYFRAMED_ANIMATION_FLAG_ROTATION, rx, ry, rz, rw);
+			anim_node->getInterpolatedFrame(i, LIBXENOVERSE_EAN_KEYFRAMED_ANIMATION_FLAG_SCALE, sx, sy, sz, sw);
+
+
+			//fbx part
+			lTime.SetSecondDouble(frame);
+
+			
+			if (string(fbx_node->GetName()).find("f_") != string::npos) {
+
+				FbxDouble3 bone_position = fbx_node->LclTranslation.Get();
+				px -= bone_position[0];
+				py -= bone_position[1];
+				pz -= bone_position[2];
+			}
+
+			//Test
+			FbxDouble3 bone_position = fbx_node->LclTranslation.Get();
+			px += bone_position[0];
+			py += bone_position[1];
+			pz += bone_position[2];
+
+
+			//position
+			lKeyIndex = fbx_animCurve_translation_x->KeyAdd(lTime);
+			fbx_animCurve_translation_x->KeySetValue(lKeyIndex, px);
+			fbx_animCurve_translation_x->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);		//TODO tester FbxAnimCurveDef::eInterpolationCubic
+
+			lKeyIndex = fbx_animCurve_translation_y->KeyAdd(lTime);
+			fbx_animCurve_translation_y->KeySetValue(lKeyIndex, py);
+			fbx_animCurve_translation_y->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+			lKeyIndex = fbx_animCurve_translation_z->KeyAdd(lTime);
+			fbx_animCurve_translation_z->KeySetValue(lKeyIndex, pz);
+			fbx_animCurve_translation_z->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+
+			//rotation
+			FbxQuaternion rotation(rx, ry, rz, rw);
+
+
+			FbxDouble3 bone_rotation_eulerAngles = fbx_node->LclRotation.Get();
+			FbxQuaternion bone_rotation;
+			bone_rotation.ComposeSphericalXYZ(bone_rotation_eulerAngles);
+
+
+			FbxQuaternion bone_rotation_inv(bone_rotation);
+			bone_rotation_inv.Inverse();
+			rotation = bone_rotation_inv * rotation;
+
+			FbxDouble4 rotation_eulerAngles = rotation.DecomposeSphericalXYZ();
+			if (rotation_eulerAngles[0] != rotation_eulerAngles[0])		//check Nan possibility
+				rotation_eulerAngles[0] = 0;
+			if (rotation_eulerAngles[1] != rotation_eulerAngles[1])		//check Nan possibility
+				rotation_eulerAngles[1] = 0;
+			if (rotation_eulerAngles[2] != rotation_eulerAngles[2])		//check Nan possibility
+				rotation_eulerAngles[2] = 0;
+
+
+			lKeyIndex = fbx_animCurve_rotation_x->KeyAdd(lTime);
+			fbx_animCurve_rotation_x->KeySetValue(lKeyIndex, rotation_eulerAngles[0]);
+			fbx_animCurve_rotation_x->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+			lKeyIndex = fbx_animCurve_rotation_y->KeyAdd(lTime);
+			fbx_animCurve_rotation_y->KeySetValue(lKeyIndex, rotation_eulerAngles[1]);
+			fbx_animCurve_rotation_y->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+			lKeyIndex = fbx_animCurve_rotation_z->KeyAdd(lTime);
+			fbx_animCurve_rotation_z->KeySetValue(lKeyIndex, rotation_eulerAngles[2]);
+			fbx_animCurve_rotation_z->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+
+
+			//scale
+			lKeyIndex = fbx_animCurve_scale_x->KeyAdd(lTime);
+			fbx_animCurve_scale_x->KeySetValue(lKeyIndex, sx);
+			fbx_animCurve_scale_x->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+			lKeyIndex = fbx_animCurve_scale_y->KeyAdd(lTime);
+			fbx_animCurve_scale_y->KeySetValue(lKeyIndex, sy);
+			fbx_animCurve_scale_y->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+
+			lKeyIndex = fbx_animCurve_scale_z->KeyAdd(lTime);
+			fbx_animCurve_scale_z->KeySetValue(lKeyIndex, sz);
+			fbx_animCurve_scale_z->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationLinear);
+		}
+		
+		
+		if (fbx_animCurve_translation_x)
+		{
+			fbx_animCurve_translation_x->KeyModifyEnd();
+			fbx_animCurve_translation_x->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_translation_y)
+		{
+			fbx_animCurve_translation_y->KeyModifyEnd();
+			fbx_animCurve_translation_y->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_translation_z)
+		{
+			fbx_animCurve_translation_z->KeyModifyEnd();
+			fbx_animCurve_translation_z->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_rotation_x)
+		{
+			fbx_animCurve_rotation_x->KeyModifyEnd();
+			fbx_animCurve_rotation_x->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_rotation_y)
+		{
+			fbx_animCurve_rotation_y->KeyModifyEnd();
+			fbx_animCurve_rotation_y->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_rotation_z)
+		{
+			fbx_animCurve_rotation_z->KeyModifyEnd();
+			fbx_animCurve_rotation_z->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_scale_x)
+		{
+			fbx_animCurve_scale_x->KeyModifyEnd();
+			fbx_animCurve_scale_x->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_scale_y)
+		{
+			fbx_animCurve_scale_y->KeyModifyEnd();
+			fbx_animCurve_scale_y->ConnectSrcObject(fbx_animCurveNode);
+		}
+		if (fbx_animCurve_scale_z)
+		{
+			fbx_animCurve_scale_z->KeyModifyEnd();
+			fbx_animCurve_scale_z->ConnectSrcObject(fbx_animCurveNode);
+		}
+		return fbx_animCurveNode;
+	}
+
+	
+	
+	
+	vector<FbxAnimCurveNode *> EAN::exportFBXAnimations(FbxScene *scene, std::vector<FbxAnimStack *> list_AnimStack, FbxNode *fbx_node, size_t indexBone) {
+		
+		vector<FbxAnimCurveNode *> fbx_anims;
+		if (fbx_node == NULL)
+			return fbx_anims;
+		
+		EANAnimation *animation;
+		int keyframes_count;
+		FbxAnimStack* lAnimStack;
+		FbxAnimLayer* lAnimLayer;
+
+		size_t nbAnims = animations.size();
+		for (size_t i = 0; i < nbAnims; i++) {
+			
+			if (i >= list_AnimStack.size())
+				break;
+
+			animation = &(animations.at(i));
+			keyframes_count = animation->getFrameCount();
+			vector<EANAnimationNode> &anim_nodes = animation->getNodes();
+			
+			lAnimStack = list_AnimStack.at(i);
+			lAnimLayer = (FbxAnimLayer*)lAnimStack->GetMember(0);
+
+
+			size_t nbAnimsNodes = anim_nodes.size();
+			for (size_t j = 0; j < nbAnimsNodes; j++) {
+
+				if (indexBone == anim_nodes.at(j).getBoneIndex())		//animations and bones are linked by the indexBone
+				{
+					FbxAnimCurveNode* fbx_anim_curveNode = createFBXAnimationCurveNode(fbx_node, animation, &anim_nodes.at(j), lAnimStack, lAnimLayer);
+					fbx_anims.push_back(fbx_anim_curveNode);
+				}
+			}
+		}
+
+
+
+
+
+
+		
+
+
+
+		/*
+		//partie ecriture.
+		int i;
+		FbxTime lTime;
+		FbxAnimCurveKey key;
+		FbxAnimCurve* lCurve = NULL;
+
+		// Create one animation stack
+		FbxAnimStack* lAnimStack = FbxAnimStack::Create(scene, "Stack001");
+
+		// this stack animation range is limited from 0 to 1 second
+		lAnimStack->LocalStop = FBXSDK_TIME_ONE_SECOND;
+		lAnimStack->Description = "This is the animation stack description field.";
+
+		// all animation stacks need, at least, one layer.
+		FbxAnimLayer* lAnimLayer = FbxAnimLayer::Create(scene, "Base Layer");	// the AnimLayer object name is "Base Layer"
+		lAnimStack->AddMember(lAnimLayer);											// add the layer to the stack
+
+
+		
+		// Set and get the blend mode bypass of the layer
+		bool val;
+		lAnimLayer->SetBlendModeBypass(eFbxTypeCount, true);       // set the bypass to all the datatypes.
+		val = lAnimLayer->GetBlendModeBypass(eFbxBool);           // val = true
+		lAnimLayer->SetBlendModeBypass(eFbxBool, false);          // overwrite just for the bool datatype.
+		val = lAnimLayer->GetBlendModeBypass(eFbxBool);           // val = false
+		val = lAnimLayer->GetBlendModeBypass(eFbxChar);           // val = true
+		val = lAnimLayer->GetBlendModeBypass(eFbxDateTime);        // val = true
+		val = lAnimLayer->GetBlendModeBypass((EFbxType)-1);     // invalid type, val = false
+		val = lAnimLayer->GetBlendModeBypass((EFbxType)120);    // invalid type (>MAX_TYPES), val = false
+
+
+		// we want to animate the layer's weight property.
+		FbxAnimCurveNode* wcn = lAnimLayer->CreateCurveNode(lAnimLayer->Weight);
+		if (wcn)
+		{
+			// the curve node from the Weight property already contains 1 channel (Weight).
+			i = wcn->GetChannelsCount();                            // i = 1
+
+
+			/*
+			// Now, let's add a second channel to the animation node. Note that this code
+			// is useless and has only been provided to show the usage of the AddChannel and
+			// ResetChannels
+			bool ret;
+			ret = wcn->AddChannel<int>("MyAddedIntChannel", 99);    // this call will succed
+			i = wcn->GetChannelsCount();                            // i = 2
+			ret = wcn->AddChannel<int>("MyAddedIntChannel", 10);    // this call will fail, since the channel already exists.
+			i = wcn->GetChannelsCount();                            // i = 2
+			wcn->ResetChannels();                                   // remove any added channels
+			i = wcn->GetChannelsCount();                            // i = 1
+		}
+		*//*
+
+		// get the Weight curve (and create it if it does not exist, wich is the case!)
+		lCurve = lAnimLayer->Weight.GetCurve(lAnimLayer, true);
+		if (lCurve)
+		{
+			// add two keys at time 0 sec and 1 sec with values 0 and 100 respectively.
+			lCurve->KeyModifyBegin();
+			for (i = 0; i < 2; i++)
+			{
+				lTime.SetSecondDouble((float)i);
+				key.Set(lTime, i*100.0f);
+				lCurve->KeyAdd(lTime, key);
+			}
+			lCurve->KeyModifyEnd();
+		}
+
+		//
+		// now create a 3 components curvenode and animate two of the three channels.
+		//
+		// first, we need a "dummy" property so we can call the CreateTypedCurveNode
+		FbxProperty p = FbxProperty::Create(scene, FbxDouble3DT, "Vector3Property");
+		p.Set(FbxDouble3(1.1, 2.2, 3.3));
+		FbxAnimCurveNode* lCurveNode = FbxAnimCurveNode::CreateTypedCurveNode(p, scene);
+
+		// let's make sure the curveNode is added to the animation layer.
+		lAnimLayer->AddMember(lCurveNode);
+
+		// and to the "Vector3Property" since CreateTypedCurveNode does not make any connection
+		p.ConnectSrcObject(lCurveNode);
+
+		//Example of channel get value:
+		//double v1 = lCurveNode->GetChannelValue<double>(0U, 0.0);   // v1 = 1.1
+		//float  v2 = lCurveNode->GetChannelValue<float> (1U, 0.0f);  // v2 = 2.2
+		//int    v3 = lCurveNode->GetChannelValue<int>   (2U, 0);     // v3 = 3
+
+		//
+		// create two free curves (not connected to anything)
+		//
+
+		// first curve
+		lCurve = FbxAnimCurve::Create(scene, "curve1");
+		if (lCurve)
+		{
+			// add two keys at time 0 sec and 1 sec with values 0 and 10 respectively.
+			lCurve->KeyModifyBegin();
+			for (i = 0; i < 2; i++)
+			{
+				lTime.SetSecondDouble((float)i);
+				key.Set(lTime, i*10.0f);
+				lCurve->KeyAdd(lTime, key);
+			}
+			lCurve->KeyModifyEnd();
+		}
+
+		// connect it to the second channel
+		lCurveNode->ConnectToChannel(lCurve, 1);
+
+
+
+		// second curve
+		lCurve = FbxAnimCurve::Create(scene, "curve2");
+		if (lCurve)
+		{
+			// add three keys at time 1, 2 and 3 sec with values 3.33, 6.66 and 9.99 respectively
+			lCurve->KeyModifyBegin();
+			for (i = 1; i < 4; i++)
+			{
+				lTime.SetSecondDouble((float)i);
+				key.Set(lTime, i*3.33f);
+				lCurve->KeyAdd(lTime, key);
+			}
+			lCurve->KeyModifyEnd();
+		}
+		// connect it to the third channel
+		lCurveNode->ConnectToChannel(lCurve, "Z"); // for backward compatibility, string identifier are still
+		// allowed for the X,Y,Z and W components or "0", "1", ... "9", "A", "B", ... "F" for the Matrix44 datatype
+
+		*/
+
+		/*
+
+		#define FBXSDK_CURVENODE_TRANSFORM		"Transform"
+		#define FBXSDK_CURVENODE_TRANSLATION	"T"
+		#define FBXSDK_CURVENODE_ROTATION		"R"
+		#define FBXSDK_CURVENODE_SCALING		"S"
+		#define FBXSDK_CURVENODE_COMPONENT_X	"X"
+		#define FBXSDK_CURVENODE_COMPONENT_Y	"Y"
+		#define FBXSDK_CURVENODE_COMPONENT_Z	"Z"
+		#define FBXSDK_CURVENODE_COLOR			"Color"
+		#define FBXSDK_CURVENODE_COLOR_RED		FBXSDK_CURVENODE_COMPONENT_X
+		#define FBXSDK_CURVENODE_COLOR_GREEN	FBXSDK_CURVENODE_COMPONENT_Y
+		#define FBXSDK_CURVENODE_COLOR_BLUE		FBXSDK_CURVENODE_COMPONENT_Z
+
+
+		void AnimateSkeleton(FbxScene* pScene, FbxNode* pSkeletonRoot)
+		{
+			FbxString lAnimStackName;
+			FbxTime lTime;
+			int lKeyIndex = 0;
+
+			FbxNode* lRoot = pSkeletonRoot;
+			FbxNode* lLimbNode1 = pSkeletonRoot->GetChild(0);
+
+			// First animation stack.
+			lAnimStackName = "Bend on 2 sides";
+			FbxAnimStack* lAnimStack = FbxAnimStack::Create(pScene, lAnimStackName);
+
+			// The animation nodes can only exist on AnimLayers therefore it is mandatory to
+			// add at least one AnimLayer to the AnimStack. And for the purpose of this example,
+			// one layer is all we need.
+			FbxAnimLayer* lAnimLayer = FbxAnimLayer::Create(pScene, "Base Layer");
+			lAnimStack->AddMember(lAnimLayer);
+
+			// Create the AnimCurve on the Rotation.Z channel
+			FbxAnimCurve* lCurve = lRoot->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+			if (lCurve)
+			{
+				lCurve->KeyModifyBegin();
+				lTime.SetSecondDouble(0.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(1.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 45.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(2.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, -45.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(3.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+				lCurve->KeyModifyEnd();
+			}
+
+			// Same thing for the next object
+			lCurve = lLimbNode1->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+			if (lCurve)
+			{
+				lCurve->KeyModifyBegin();
+				lTime.SetSecondDouble(0.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(1.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, -90.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(2.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 90.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(3.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+				lCurve->KeyModifyEnd();
+			}
+
+			// Second animation stack.
+			lAnimStackName = "Bend and turn around";
+			lAnimStack = FbxAnimStack::Create(pScene, lAnimStackName);
+
+			// The animation nodes can only exist on AnimLayers therefore it is mandatory to
+			// add at least one AnimLayer to the AnimStack. And for the purpose of this example,
+			// one layer is all we need.
+			lAnimLayer = FbxAnimLayer::Create(pScene, "Base Layer");
+			lAnimStack->AddMember(lAnimLayer);
+
+			// Create the AnimCurve on the Rotation.Y channel
+			lCurve = lRoot->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Y, true);
+			if (lCurve)
+			{
+				lCurve->KeyModifyBegin();
+				lTime.SetSecondDouble(0.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(2.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 720.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+				lCurve->KeyModifyEnd();
+			}
+
+			lCurve = lLimbNode1->LclRotation.GetCurve(lAnimLayer, FBXSDK_CURVENODE_COMPONENT_Z, true);
+			if (lCurve)
+			{
+				lCurve->KeyModifyBegin();
+				lTime.SetSecondDouble(0.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(1.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 90.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+
+				lTime.SetSecondDouble(2.0);
+				lKeyIndex = lCurve->KeyAdd(lTime);
+				lCurve->KeySetValue(lKeyIndex, 0.0);
+				lCurve->KeySetInterpolation(lKeyIndex, FbxAnimCurveDef::eInterpolationCubic);
+				lCurve->KeyModifyEnd();
+			}
+		}
+		*/
+
+
+		return fbx_anims;
+	}
+#endif
 }

--- a/LibXenoverse/LibXenoverse/EAN.h
+++ b/LibXenoverse/LibXenoverse/EAN.h
@@ -162,6 +162,11 @@ namespace LibXenoverse {
 		string getName() {
 			return name;
 		}
+
+#ifdef LIBXENOVERSE_FBX_SUPPORT
+		FbxAnimCurveNode *createFBXAnimationCurveNode(FbxNode *fbx_node, EANAnimation *animation, EANAnimationNode* anim_node, FbxAnimStack *lAnimStack, FbxAnimLayer* lAnimLayer);
+		vector<FbxAnimCurveNode *>  exportFBXAnimations(FbxScene *scene, std::vector<FbxAnimStack *> list_AnimStack, FbxNode *fbx_node, size_t indexBone);
+#endif
 	};
 }
 

--- a/LibXenoverse/LibXenoverse/EMB.h
+++ b/LibXenoverse/LibXenoverse/EMB.h
@@ -75,6 +75,10 @@ namespace LibXenoverse {
 			string getName() {
 				return name;
 			}
+
+			#ifdef LIBXENOVERSE_FBX_SUPPORT
+			void exportShadersToFx(EMB *shader_pack_vs,  EMB *shader_pack_ps);
+			#endif
 	};
 }
 

--- a/LibXenoverse/LibXenoverse/EMBExportFx.cpp
+++ b/LibXenoverse/LibXenoverse/EMBExportFx.cpp
@@ -1,0 +1,213 @@
+namespace LibXenoverse {
+	
+#ifdef LIBXENOVERSE_FBX_SUPPORT
+	
+	void EMB::exportShadersToFx(EMB *shader_pack_vs, EMB *shader_pack_ps) {
+		
+		vector<EMBFile *> vs_files = shader_pack_vs->getFiles();
+		vector<EMBFile *> ps_files = shader_pack_ps->getFiles();
+
+		for (size_t i = 0; i < vs_files.size(); i++)
+		{
+			EMBFile *vs_file = vs_files.at(i);
+
+			string shader_name_vs = nameFromFilenameNoExtension(vs_file->getName());
+			string extension_vs = extensionFromFilename(vs_file->getName());
+			
+			if ((extension_vs != "xvu") && (extension_vs != "xpu"))			//if not a shader, ignore
+				continue;
+			
+			string test = shader_name_vs.substr(shader_name_vs.size() - 5);
+			
+			string shader_name = shader_name_vs;
+			if (shader_name_vs.substr(shader_name_vs.size() - 5) == "_W_VS")			//filter like EMMOGre. Todo see why
+				shader_name = shader_name_vs.substr(0, shader_name_vs.size() - 5);
+			else if(shader_name_vs.substr(shader_name_vs.size() - 3) == "_PS")
+				shader_name = shader_name_vs.substr(0, shader_name_vs.size() - 3);
+			else
+				continue;
+
+			EMBFile *ps_file = NULL;
+			for (size_t j = 0; j < ps_files.size(); j++)					//search  for a couple
+			{
+				string shader_name_ps = nameFromFilenameNoExtension(ps_files.at(j)->getName());				
+				if ((shader_name_ps.substr(shader_name_ps.size() - 5) != "_W_VS") && (shader_name_ps.substr(shader_name_ps.size() - 3) != "_PS"))	//filter like EMMOGre. Todo see why
+					continue;
+
+				if ((shader_name_ps.size() >= shader_name.size() + 3) && (shader_name_ps.substr(0, shader_name.size()) == shader_name))
+				{
+					ps_file = ps_files.at(j);
+					break;
+				}
+			}
+			
+			if (ps_file == NULL)			//if we not found a couple vs - ps, we do nothing
+				continue;
+
+
+			
+			string extension_ps = extensionFromFilename(ps_file->getName());
+			if ((extension_ps != "xvu") && (extension_ps != "xpu"))
+				continue;
+
+			if ((extension_vs != "xvu") || (extension_ps != "xpu"))			//resolve inversion or the same definition
+			{
+				if ((extension_vs == "xpu") && (extension_ps == "xvu"))		//inversion
+				{
+					EMBFile *file_tmp = vs_file;
+					vs_file = ps_file;
+					ps_file = file_tmp;
+					extension_vs = "xvu";
+					extension_ps = "xpu";
+				} else {													//others
+					continue;
+				}
+			}
+
+
+
+			size_t size = vs_file->getSize();
+			char *new_data_vs = HLSLASM::disassemble(vs_file->getData(), size);
+			size = ps_file->getSize();
+			char *new_data_ps = HLSLASM::disassemble(ps_file->getData(), size);
+
+
+			// Fx declaration, with some parameters available to change in 3dsmax's DirectX material interface,
+			// with definitions like Ogre for material/shader program
+			string fx_str = "\
+// This is used by 3dsmax to load the correct parser\n\
+string ParamID = \"0x0\";\n\
+\n\
+// transformations\n\
+float4x4 worldViewProj : WORLDVIEWPROJ;\n\
+float4 cameraPos : CAMERAPOSITION;\n\
+float4x3 world_matrix_array[24] : WORLDMATRIXARRAY;\n\
+\n\
+float4 lightPos : LIGHTPOS;\n\
+\n\
+texture g_ImageSampler1 <\n\
+string UIName = \"g_ImageSampler1\";\n\
+string name = \"xxx_0.dds\";\n\
+string ResourceType = \"2D\";\n\
+>;\n\
+\n\
+texture g_SamplerToon <\n\
+string UIName = \"g_SamplerToon\";\n\
+string name = \"xxx.dyt_0.dds\";\n\
+string ResourceType = \"2D\";\n\
+>;\n\
+\n\
+texture g_ImageSamplerTemp14 <\n\
+string UIName = \"g_ImageSamplerTemp14\";\n\
+string name = \"xxx.dyt_1.dds\";\n\
+string ResourceType = \"2D\";\n\
+>;\n\
+\n\
+float4 g_vFadeMulti_PS < string UIName = \"g_vFadeMulti_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_vFadeRim_PS 	 < string UIName = \"g_vFadeRim_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_vFadeAdd_PS 	 < string UIName = \"g_vFadeAdd_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+\n\
+float4 MatCol0 < string UIName = \"MatCol0\"; > = float4(0.0f, 0.0f, 0.0f, 1.0f);\n\
+float4 MatCol1 < string UIName = \"MatCol1\"; > = float4(0.16129f, 0.10484f, 0.04032f, 1.0f);\n\
+float4 MatCol2 < string UIName = \"MatCol2\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 MatCol3 < string UIName = \"MatCol3\"; > = float4(0.0f, 0.0f, 1.0f, 1.0f);		//Battle Damage :   x = Scratch Mark Multiplier, y = Blood Mark Multiplier (forced to 0.0)\n\
+float4 MatScale0 < string UIName = \"MatScale0\"; > = float4(1.0f, 1.0f, 1.0f, 0.03f);\n\
+float4 MatScale1 < string UIName = \"MatScale1\"; > = float4(0.0f, 1.0f, 1.0f, 1.0f);\n\
+\n\
+float4 g_vColor0_PS 	 < string UIName = \"g_vColor0_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_vColor1_PS 	 < string UIName = \"g_vColor1_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_vColor2_PS 	 < string UIName = \"g_vColor2_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_vColor12_PS 	 < string UIName = \"g_vColor12_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_Color_Multiplier < string UIName = \"g_Color_Multiplier\"; > = float4(1.0f, 1.0f, 1.0f, 1.0f);\n\
+float4 g_vParam4_PS 	 < string UIName = \"g_vParam4_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_vParam5_PS 	 < string UIName = \"g_vParam5_PS\"; > = float4(0.0f, 0.0f, 0.0f, 0.0f);\n\
+float4 g_Toon_Detail 	 < string UIName = \"g_Toon_Detail\"; > = float4(0.0f, 23.2558f, 0.04587f, 0.0f);\n\
+\n\
+////////////////////////////////////////////////////////////////////////////////\n\
+technique DefaultTechnique\n\
+{\n\
+	pass P0\n\
+	{\n\
+		CullMode = CW;\n\
+		Lighting = true;\n\
+		SHADEMODE = GOURAUD;\n\
+		ZEnable = true;\n\
+		ZWriteEnable = true;\n\
+		\n\
+		VertexShaderConstant[0] = <worldViewProj>;\n\
+		VertexShaderConstant[72] = <cameraPos>;\n\
+		VertexShaderConstant[104] = <world_matrix_array>;\n\
+		\n\
+		PixelShaderConstant[51] = <g_vFadeMulti_PS>;\n\
+		PixelShaderConstant[52] = <g_vFadeRim_PS>;\n\
+		PixelShaderConstant[53] = <g_vFadeAdd_PS>;\n\
+		\n\
+		PixelShaderConstant[64] = <lightPos>;\n\
+		\n\
+		PixelShaderConstant[84] = <MatCol0>;\n\
+		PixelShaderConstant[85] = <MatCol1>;\n\
+		PixelShaderConstant[86] = <MatCol2>;\n\
+		PixelShaderConstant[87] = <MatCol3>;\n\
+		PixelShaderConstant[92] = <MatScale0>;\n\
+		PixelShaderConstant[93] = <MatScale1>;\n\
+		\n\
+		PixelShaderConstant[105] = <g_vColor0_PS>;\n\
+		PixelShaderConstant[106] = <g_vColor1_PS>;\n\
+		PixelShaderConstant[107] = <g_vColor2_PS>;\n\
+		PixelShaderConstant[117] = <g_vColor12_PS>;\n\
+		PixelShaderConstant[139] = <g_Color_Multiplier>;\n\
+		PixelShaderConstant[140] = <g_vParam4_PS>;\n\
+		PixelShaderConstant[141] = <g_vParam5_PS>;\n\
+		PixelShaderConstant[142] = <g_Toon_Detail>;\n\
+		\n\
+		Texture[1] = <g_ImageSampler1>;\n\
+		MinFilter[1] = Linear;\n\
+		MagFilter[1] = Linear;\n\
+		MipFilter[1] = Linear;\n\
+		MipMapLodBias[1] = 0;\n\
+		//AddressU[1] = Clamp;\n\
+		//AddressV[1] = Clamp;\n\
+		\n\
+		Texture[4] = <g_SamplerToon>;\n\
+		MinFilter[4] = None;\n\
+		MagFilter[4] = None;\n\
+		MipFilter[4] = None;\n\
+		MipMapLodBias[4] = 0;\n\
+		//AddressU[4] = Clamp;\n\
+		//AddressV[4] = Clamp;\n\
+		\n\
+		Texture[14] = <g_ImageSamplerTemp14>;\n\
+		MinFilter[14] = Linear;\n\
+		MagFilter[14] = Linear;\n\
+		MipFilter[14] = Linear;\n\
+		MipMapLodBias[14] = 0;\n\
+		//AddressU[14] = Clamp;\n\
+		//AddressV[14] = Clamp;\n\
+		\n\
+		VertexShader = asm\n\
+		{\n\
+					" + string(new_data_vs) + " \n\
+		};\n\
+		\n\
+		PixelShader = asm\n\
+		{\n\
+					" + string(new_data_ps) + " \n\
+		};\n\
+	}\n\
+}\n";
+
+			delete new_data_vs;
+			delete new_data_ps;
+
+			//save file
+			{
+				File file(shader_name +".fx", LIBXENOVERSE_FILE_WRITE_TEXT);
+				if (file.valid()) {
+					file.writeString(&fx_str);
+					file.close();
+				}
+			}
+		}
+	}
+#endif
+}

--- a/LibXenoverse/LibXenoverse/EMD.h
+++ b/LibXenoverse/LibXenoverse/EMD.h
@@ -4,6 +4,8 @@
 #define LIBXENOVERSE_EMD_SIGNATURE           "#EMD"
 #define LIBXENOVERSE_EMD_SUBMESH_BONE_LIMIT  24
 
+#include "EMM.h"
+
 namespace LibXenoverse {
 	class EMDVertex {
 		friend class EMD;
@@ -257,9 +259,9 @@ namespace LibXenoverse {
 			void setVertexScale(float scale);
 
 			#ifdef LIBXENOVERSE_FBX_SUPPORT
-				FbxMesh *exportFBX(FbxScene *scene, FbxNode *lMeshNode);
+				FbxMesh *exportFBX(FbxScene *scene, FbxNode *lMeshNode, string path);
 				void exportFBXSkin(FbxScene *scene, FbxMesh *fbx_mesh, vector<FbxNode *> &fbx_bones, FbxAMatrix skin_matrix);
-				FbxSurfacePhong *exportFBXMaterial(FbxScene *scene, string material_name);
+				FbxSurfaceMaterial *exportFBXMaterial(FbxScene *scene, string material_name, EMM *material, EMB *texture_pack, EMB *texture_dyt_pack);
 				void importFBX(FbxNode *lNode);
 			#endif
 

--- a/LibXenoverse/LibXenoverse/LibXenoverse.vcxproj
+++ b/LibXenoverse/LibXenoverse/LibXenoverse.vcxproj
@@ -63,6 +63,9 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <Lib>
+      <AdditionalDependencies>d3dcompiler.lib;D3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -81,6 +84,9 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <Lib>
+      <AdditionalDependencies>d3dcompiler.lib;D3dx9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Lib>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="AGD.h" />
@@ -117,6 +123,7 @@
     <ClCompile Include="EANKeyframe.cpp" />
     <ClCompile Include="EANAnimationNode.cpp" />
     <ClCompile Include="EMB.cpp" />
+    <ClCompile Include="EMBExportFx.cpp" />
     <ClCompile Include="EMBFile.cpp" />
     <ClCompile Include="EMD.cpp" />
     <ClCompile Include="EMDExportFBX.cpp" />

--- a/LibXenoverse/LibXenoverse/LibXenoverse.vcxproj.filters
+++ b/LibXenoverse/LibXenoverse/LibXenoverse.vcxproj.filters
@@ -230,5 +230,8 @@
     <ClCompile Include="EANKeyframedAnimation.cpp">
       <Filter>EAN</Filter>
     </ClCompile>
+    <ClCompile Include="EMBExportFx.cpp">
+      <Filter>EMB</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/LibXenoverse/emdfbx/main.cpp
+++ b/LibXenoverse/emdfbx/main.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv) {
 
 	vector<string> model_filenames;
 	vector<string> skeleton_filenames;
+	vector<string> animation_filenames;
 	string export_filename = "";
 
 	for (int i = 1; i < argc; i++)  {
@@ -24,6 +25,10 @@ int main(int argc, char** argv) {
 
 		if (extension == "esk") {
 			skeleton_filenames.push_back(parameter);
+		}
+
+		if (extension == "ean") {
+			animation_filenames.push_back(parameter);
 		}
 
 		if (extension == "fbx") {
@@ -52,9 +57,59 @@ int main(int argc, char** argv) {
 	// Create Scene
 	vector<FbxNode *> global_fbx_bones;
 	global_fbx_bones.reserve(300);
+	vector<size_t> global_fbx_bones_index;													//TODO find a better way to link skeleton and animations
+	global_fbx_bones_index.reserve(300);
+
+	vector<FbxAnimCurveNode *> global_fbx_animation;
+	global_fbx_animation.reserve(300);
 
 	FbxScene *scene = FbxScene::Create(sdk_manager, "EMDFBXScene");
 
+
+	// Load Shaders and convert it to fx file (will be use by fbx).
+	vector<string> shader_names;
+	shader_names.push_back("adam_shader/shader_age_vs.emb");								//must specified vs folloxed by ps shaders
+	shader_names.push_back("adam_shader/shader_age_ps.emb");
+	shader_names.push_back("adam_shader/shader_default_vs.emb");
+	shader_names.push_back("adam_shader/shader_default_ps.emb");
+	
+
+	bool needs_install_shaders = false;
+	for (size_t i = 0; i < shader_names.size(); i++) {
+		if (!LibXenoverse::fileCheck(shader_names[i])) {
+			needs_install_shaders = true;
+			break;
+		}
+	}
+
+	if (needs_install_shaders) {
+		printf("Shaders not found. Please use Xenoviewer to prepare shaders in bin folder.");
+		return -1;
+	}
+
+	for (size_t i = 0; i+1 < shader_names.size(); i+=2) {
+		
+		LibXenoverse::EMB *shader_pack_vs = new LibXenoverse::EMB();
+		LibXenoverse::EMB *shader_pack_ps = new LibXenoverse::EMB();
+
+		if (!shader_pack_vs->load(shader_names[i])) {
+			delete shader_pack_vs;
+			printf("Couldn't load Shader Pack %s. File is either missing, open by another application, or corrupt.", shader_names[i].c_str());
+			continue;
+		}
+		if (!shader_pack_ps->load(shader_names[i+1])) {
+			delete shader_pack_vs;
+			delete shader_pack_ps;
+			printf("Couldn't load Shader Pack %s. File is either missing, open by another application, or corrupt.", shader_names[i].c_str());
+			continue;
+		}
+
+		shader_pack_vs->exportShadersToFx(shader_pack_vs, shader_pack_ps);					//convert all shaders in fx file with defaults program parameters (like Ogre's version).
+	}
+
+
+
+	//build FBX skeleton
 	for (size_t i = 0; i < skeleton_filenames.size(); i++) {
 		LibXenoverse::ESK *esk_skeleton = new LibXenoverse::ESK();
 		esk_skeleton->load(skeleton_filenames[i]);
@@ -62,11 +117,60 @@ int main(int argc, char** argv) {
 
 		for (size_t j = 0; j < fbx_bones.size(); j++) {
 			global_fbx_bones.push_back(fbx_bones[j]);
+			global_fbx_bones_index.push_back(j);											//kepp index of bone to link with animations.
 		}
 	}
 
+
+
+	//build FBX animations
+	for (size_t i = 0; i < animation_filenames.size(); i++) {
+		
+		string filename = animation_filenames.at(i);
+		string ean_name = LibXenoverse::nameFromFilenameNoExtension(filename, true);
+
+		//vector<FbxAnimCurveNode *> global_fbx_animation;
+
+		LibXenoverse::EAN *animation = new LibXenoverse::EAN();
+		if (animation->load(filename)) {
+
+			std::vector<FbxAnimStack *> list_AnimStack;
+			size_t nbAnims = animation->getAnimations().size();
+			for (size_t j = 0; j < nbAnims; j++) {													//we create only one stack and one layer by animation. each will animate all bones of all skeleton.
+
+				LibXenoverse::EANAnimation *anim_tmp = &(animation->getAnimations().at(j));
+
+				FbxAnimStack* lAnimStack = FbxAnimStack::Create(scene, anim_tmp->getName().c_str());
+				FbxAnimLayer* lAnimLayer = FbxAnimLayer::Create(scene, (anim_tmp->getName() + "_Layer0").c_str());
+				lAnimStack->AddMember(lAnimLayer);
+
+				list_AnimStack.push_back(lAnimStack);
+			}
+
+			size_t k = 0;
+			for (vector<FbxNode *>::iterator it = global_fbx_bones.begin(); it != global_fbx_bones.end(); it++) {
+
+				vector<FbxAnimCurveNode *> fbx_anim = animation->exportFBXAnimations(scene, list_AnimStack, *it, global_fbx_bones_index.at(k));
+
+				for (size_t j = 0; j < fbx_anim.size(); j++) {
+					global_fbx_animation.push_back(fbx_anim[j]);
+				}
+				k++;
+			}
+		}
+		else {
+			delete animation;
+			animation = NULL;
+		}
+	}
+
+
+
+
 	for (size_t i = 0; i < model_filenames.size(); i++) {
 		string node_name = LibXenoverse::nameFromFilenameNoExtension(model_filenames[i]);
+		string path = model_filenames[i].substr(0, model_filenames[i].size() - LibXenoverse::nameFromFilename(model_filenames[i]).size());
+
 		LibXenoverse::EMD *emd_model = new LibXenoverse::EMD();
 		emd_model->load(model_filenames[i]);
 
@@ -80,7 +184,7 @@ int main(int argc, char** argv) {
 		lMeshNode->LclRotation.Set(FbxVector4(0, 0, 0));
 
 		// Create and attach Mesh
-		FbxMesh *lMesh = emd_model->exportFBX(scene, lMeshNode);
+		FbxMesh *lMesh = emd_model->exportFBX(scene, lMeshNode, path);
 		lMeshNode->SetNodeAttribute(lMesh);
 
 		if (global_fbx_bones.size()) {


### PR DESCRIPTION
-create fbx material with fx files and texture embended from DBX's material inspired by Ogre's material created for Xenoviewer.
=> 3dsmax 2015 have DirectX shader Material witch could use fx file. but FBX import didn't work well : It read there are directX shader Material but didn't configure it (parameter, texture and fx used).
=> Unity read all texture and Fx file embended in FBX file, but it's can't use fx for material definition. and cgFx file didn't work. Unity material with shader definition didn't use asm shader.
I keep that because the solution is to generate a maxscript file witch update Material DirectX shader for using DBX material in 3dsmax.
For Unity, I will to sse another solution.

Why I commit:
-add skeleton's animations in FBX file, if you add ean file in argument of emdfbx.exe.
=> Work well with unity. you could play with all animations directly (aniamtion viewer when you click on a animation)
=> in 3dsmax you have to use menu->import file and select the only one animation.
